### PR TITLE
Fixes for Flak Vests, Broken Fast Walk & Mutants

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -279,7 +279,7 @@ GLOBAL_LIST_INIT(bone_dancer_recipes, list(
 	lose_text = span_danger("You start tromping around like a barbarian.")
 	medical_record_text = "Patient's dexterity belies a strong capacity for stealth."
 
-
+/*
 /datum/quirk/quick_step
 	name = "Speed Walker"
 	desc = "You walk with determined strides, and out-pace most people - at least, if you're both walking."
@@ -288,7 +288,7 @@ GLOBAL_LIST_INIT(bone_dancer_recipes, list(
 	gain_text = span_notice("You feel determined. No time to lose.")
 	lose_text = span_danger("You feel less determined. What's the rush, man?")
 	medical_record_text = "Patient scored highly on racewalking tests."
-
+*/
 
 /datum/quirk/musician
 	name = "Musician"

--- a/code/modules/clothing/suits/bigiron_suits_factions.dm
+++ b/code/modules/clothing/suits/bigiron_suits_factions.dm
@@ -318,6 +318,10 @@ Suits. 0-10 in its primary value, slowdown 0, various utility
 	desc = "A standard issue NCR Infantry vest reinforced with a thin kelvar sheet."
 	icon_state = "ncr_kelvar_vest"
 	item_state = "ncr_kelvar_vest"
+	salvage_loot = list(/obj/item/stack/crafting/armor_plate = 1)
+	armor = ARMOR_VALUE_LIGHT
+	armor_tier_desc = ARMOR_CLOTHING_LIGHT
+	slowdown = ARMOR_SLOWDOWN_LIGHT * ARMOR_SLOWDOWN_GLOBAL_MULT
 	armor_tokens = list()
 
 /obj/item/clothing/suit/armor/ncrarmor/reinforced

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -18,6 +18,8 @@
 		. -= SSI.config_entry_value
 	if(m_intent == MOVE_INTENT_WALK && HAS_TRAIT(src, TRAIT_SPEEDY_STEP))
 		. -= 1.25
+	if(HAS_TRAIT(src, TRAIT_SMUTANT))
+        . -= 0.5
 	. += calc_movespeed_mod_from_special() // S.P.E.C.I.A.L.
 
 /mob/living/carbon/human/slip(knockdown_amount, obj/O, lube)


### PR DESCRIPTION
Sets the flak vest to light type again, parent issue.
Also gives Super Mutants a default slowdown.
Nukes fast walker since it does not interact well with AGI stat at all.