### PR TITLE
Removal of a furry's snowflake gun, balancing of the R82, MP5SD, PSSH. G11 burst from 3 to 5.

### DIFF
--- a/code/game/objects/effects/spawners/f13lootdrop.dm
+++ b/code/game/objects/effects/spawners/f13lootdrop.dm
@@ -960,7 +960,6 @@
 				/obj/item/gun/ballistic/automatic/pistol/pistol14/lildevil,
 				/obj/item/gun/ballistic/shotgun/automatic/combat/neostead,
 				/obj/item/gun/ballistic/revolver/ghoulgun,
-				/obj/item/gun/ballistic/automatic/g11/tox
 				)
 
 

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -134,7 +134,7 @@
 	icon_state = "enbloc-8"
 	ammo_type = /obj/item/ammo_casing/a308
 	caliber = list(CALIBER_308)
-	max_ammo = 8
+	max_ammo = 10
 	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
 	w_class = WEIGHT_CLASS_SMALL
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -580,7 +580,7 @@
 	damage_multiplier = GUN_EXTRA_DAMAGE_T1
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION // Accurate semiauto fire
 	init_firemodes = list(
-		/datum/firemode/automatic/rpm200,
+		/datum/firemode/automatic/rpm300,
 		/datum/firemode/semi_auto/faster
 	)
 	silenced = TRUE
@@ -607,7 +607,7 @@
 	weapon_weight = GUN_ONE_HAND_ONLY
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_firemodes = list(
-		/datum/firemode/automatic/rpm300,
+		/datum/firemode/automatic/rpm400,
 		/datum/firemode/semi_auto/fast
 	)
 	scope_state = "AEP7_scope"
@@ -1378,8 +1378,8 @@
 	mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	init_mag_type = /obj/item/ammo_box/magazine/m556/rifle
 	weapon_class = WEAPON_CLASS_RIFLE
-	weapon_weight = GUN_ONE_HAND_ONLY
-	damage_multiplier = GUN_EXTRA_DAMAGE_T1
+	weapon_weight = GUN_TWO_HAND_ONLY
+	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_recoil = RIFLE_RECOIL(1.2)
 	init_firemodes = list(
 		/datum/firemode/semi_auto/fast
@@ -2134,8 +2134,7 @@
 	cock_delay = GUN_COCK_RIFLE_BASE
 	init_recoil = RIFLE_RECOIL(0.8)
 	init_firemodes = list(
-		/datum/firemode/automatic/rpm300,
-		/datum/firemode/burst/two/slow
+		/datum/firemode/automatic/rpm200,
 	)
 	zoomable = TRUE
 	fire_sound = 'sound/f13weapons/bozar_fire.ogg'
@@ -2351,7 +2350,7 @@
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
 	init_recoil = RIFLE_RECOIL(0.8)
 	init_firemodes = list(
-		/datum/firemode/burst/three/slow,
+		/datum/firemode/burst/five/slow,
 		/datum/firemode/semi_auto
 	)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
@@ -2359,9 +2358,9 @@
 
 //worn g11
 
-/obj/item/gun/ballistic/automatic/g11/tox
-	name = "Tox's G11M"
-	desc = "A unique G11. With a built in scope and semi-automatic only option, this G11 was bought and repurposed by a wealthy felid named Tox Mckit. Etched on the reciever is a lovely motif of moths and felines surrounding one singular feline under a full moon. On the scope is a engraving that says 'To the sands we stride on'"
+/obj/item/gun/ballistic/automatic/g11/worn
+	name = "Worn G11"
+	desc = "With a built in scope and semi-automatic only option, this G11 was unfortunately acquired and 'repurposed' by a gunsmith who botched the job. Etched on the reciever is a crude attempt at a peace sign, go figure."
 	icon_state = "g11"
 	item_state = "arg"
 	mag_type = /obj/item/ammo_box/magazine/m473
@@ -2376,7 +2375,7 @@
 		/datum/firemode/semi_auto
 	)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
-	can_scope = FALSE
+	can_scope = TRUE
 	zoom_factor = 1
 /* * * * * * * * * * *
  * WT-550 Carbine

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -383,6 +383,7 @@
 		/datum/firemode/semi_auto/fast
 	)
 
+/*
 // Tox's C96. slightly less damage for a 9mm pistol, but bigger magazine and better recoil
 /obj/item/gun/ballistic/automatic/pistol/type17/c96auto/tox
 	name = "Tox's C96"
@@ -390,7 +391,7 @@
 	init_firemodes = list(
 		/datum/firemode/semi_auto/fast
 	)
-
+*/
 /* * * * * * * * * * *
  * Sig P220
  * Light Mediumer pistol

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -306,7 +306,7 @@
 	sawn_desc = "A hunting rifle, crudely shortened with a saw. It's far from accurate, but the short barrel makes it quite portable."
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_TWO_HAND_ONLY
-	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	damage_multiplier = GUN_EXTRA_DAMAGE_T2
 	init_recoil = RIFLE_RECOIL(3)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 	can_scope = TRUE
@@ -337,7 +337,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_TWO_HAND_ONLY
-	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	damage_multiplier = GUN_EXTRA_DAMAGE_T2
 	init_recoil = RIFLE_RECOIL(3)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 	can_scope = TRUE
@@ -365,7 +365,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/hunting/remington
 	weapon_class = WEAPON_CLASS_RIFLE
 	weapon_weight = GUN_TWO_HAND_ONLY
-	damage_multiplier = GUN_EXTRA_DAMAGE_0
+	damage_multiplier = GUN_EXTRA_DAMAGE_T3
 
 /obj/item/gun/ballistic/rifle/hunting/remington/attackby(obj/item/A, mob/user, params) //DO NOT BUBBA YOUR STANDARD ISSUE RIFLE SOLDIER!
 	if(istype(A, /obj/item/circular_saw) || istype(A, /obj/item/gun/energy/plasmacutter))


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Should fix quite a few player gripes and bring a number of weapons into the realm of usable, namely the 2 SMGs mentioned. G11 has zero pen, so changing burst from 3 to 5 just made it slightly better; it doesn't shoot like a fucking AN-94 so don't worry. For better details on it all, look at the changelog.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
balance: G11 burst from 3 to 5
balance: R-82 RPM from 300 to 200 (holy shit)
balance: Hunting rifles and variants given slight damage increase
balance: Furry slop pistol commented out
balance: Furry slop rifle converted to worn variant and removed from loot pool
balance: SKS clip changed from 8 to 10
balance: MP5SD RPM from 200 to 300
balance: PPSh RPM from 300 to 400
balance: Worn G11 can now scope in
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
